### PR TITLE
Add Cross compiling and correct demo makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ or
 cd zynq-xdma/dev/
 make KDIR=../../linux-xlnx
 ```
+##CROSS COMPILING
+ For cross compiling, please make sure that the environnement varaible CROSS_COMPILE point toward your compilation toolchain.
+ Use for /dev
+  make ARCH=<your architecture>  KDIR=../../linux-xlnx
+  eg for zynq :
+  make ARCH=arm KDIR=../../linux-xlnx
+ Use for /lib
+  make ARCH=<your architecture>  
+Use for /demo
+  make ARCH=<your architecture>
+ 
+##Compile order
+Compile directories in that order 
+First : /dev
+Second : /lib
+Third : /demo
 
 
 ## Inserting Module

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,4 +1,5 @@
 obj-m += xdma.o
+CC=${CROSS_COMPILE}gcc
 
 # Path to the Linux kernel, if not passed in as arg, set default.
 ifeq ($(KDIR),)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC = ${CROSS_COMPILE}gcc
 LDFLAGS := -lxdma
 CFLAGS := -c -Wall -Werror
 INCLUDES := -I. -I../dev


### PR DESCRIPTION
Add Cross compiling by supporting the standard CROSS_COMPILE variable

Correct the demo makefile that was unabled to compile.
